### PR TITLE
feat: auto-update with electron-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,35 +38,7 @@ jobs:
       - name: Build app
         run: npm run build
 
-      - name: Package (${{ matrix.platform }})
-        run: npx electron-builder --${{ matrix.platform }} --publish never
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-${{ matrix.platform }}
-          path: |
-            release/*.dmg
-            release/*.zip
-            release/*.exe
-            release/*.AppImage
-            release/*.deb
-          if-no-files-found: ignore
-
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          generate_release_notes: true
-          files: artifacts/*
+      - name: Package & publish (${{ matrix.platform }})
+        run: npx electron-builder --${{ matrix.platform }} --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 out/
 dist/
 release/
+update-server/
+test-old-version/
 *.log
 .DS_Store
 Thumbs.db

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,0 +1,2 @@
+provider: generic
+url: http://localhost:8080

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,3 +25,8 @@ linux:
     - deb
   category: Education
   artifactName: ${name}-${version}-${arch}.${ext}
+publish:
+  provider: github
+  owner: ttiimmaahh
+  repo: praxis
+  releaseType: draft

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxis",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxis",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
@@ -38,6 +38,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "electron-updater": "^6.8.3",
         "lowlight": "^3.3.0",
         "lucide-react": "^1.7.0",
         "platejs": "^52.3.21",
@@ -6779,7 +6780,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -8212,6 +8212,69 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-vite": {
       "version": "5.0.0",
@@ -10533,7 +10596,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -10837,6 +10899,19 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.mapvalues": {
@@ -13855,7 +13930,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -14974,6 +15048,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Desktop course authoring and learning platform for technical developer training",
   "author": {
     "name": "Tim Pearson",
@@ -54,6 +54,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "electron-updater": "^6.8.3",
     "lowlight": "^3.3.0",
     "lucide-react": "^1.7.0",
     "platejs": "^52.3.21",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { getWindowState, trackWindowState } from './lib/window-state'
 import { getTitleBarOverlayOptions } from './lib/title-bar-overlay'
 import { registerIpcHandlers } from './ipc-handlers'
+import { initAutoUpdater } from './lib/auto-updater'
 
 const isMac = process.platform === 'darwin'
 
@@ -56,7 +57,8 @@ function createWindow(): BrowserWindow {
 
 app.whenReady().then(() => {
   registerIpcHandlers()
-  createWindow()
+  const mainWindow = createWindow()
+  initAutoUpdater(mainWindow)
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { getTitleBarOverlayForIsDark } from './lib/title-bar-overlay'
+import { checkForUpdates, quitAndInstall } from './lib/auto-updater'
 import {
   readDirectory,
   readFileContent,
@@ -190,6 +191,18 @@ export function registerIpcHandlers(): void {
       return unmarkLessonComplete(courseRoot, modulePath, lessonPath)
     }
   )
+
+  ipcMain.handle('app:getVersion', () => {
+    return app.getVersion()
+  })
+
+  ipcMain.handle('updater:checkForUpdates', async () => {
+    await checkForUpdates()
+  })
+
+  ipcMain.handle('updater:quitAndInstall', () => {
+    quitAndInstall()
+  })
 
   ipcMain.handle('window:setTitleBarOverlay', (event, payload: { isDark: boolean }) => {
     if (process.platform === 'darwin') return

--- a/src/main/lib/auto-updater.ts
+++ b/src/main/lib/auto-updater.ts
@@ -1,0 +1,50 @@
+import { BrowserWindow, app } from 'electron'
+import { autoUpdater, UpdateInfo } from 'electron-updater'
+
+let mainWindow: BrowserWindow | null = null
+
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000 // 4 hours
+const STARTUP_DELAY_MS = 3000
+
+function sendToRenderer(channel: string, ...args: unknown[]): void {
+  mainWindow?.webContents.send(channel, ...args)
+}
+
+export function initAutoUpdater(window: BrowserWindow): void {
+  if (!app.isPackaged) return
+
+  mainWindow = window
+
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+
+  autoUpdater.on('update-available', (info: UpdateInfo) => {
+    sendToRenderer('updater:available', { version: info.version, releaseNotes: info.releaseNotes })
+  })
+
+  autoUpdater.on('download-progress', (progress) => {
+    sendToRenderer('updater:progress', { percent: progress.percent })
+  })
+
+  autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
+    sendToRenderer('updater:downloaded', { version: info.version, releaseNotes: info.releaseNotes })
+  })
+
+  autoUpdater.on('error', (err: Error) => {
+    sendToRenderer('updater:error', { message: err.message })
+  })
+
+  // Check after a short startup delay, then periodically
+  setTimeout(() => {
+    autoUpdater.checkForUpdates()
+    setInterval(() => autoUpdater.checkForUpdates(), CHECK_INTERVAL_MS)
+  }, STARTUP_DELAY_MS)
+}
+
+export function checkForUpdates(): Promise<void> {
+  return autoUpdater.checkForUpdates().then(() => undefined)
+}
+
+export function quitAndInstall(): void {
+  autoUpdater.quitAndInstall(false, true)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,8 @@ import { contextBridge, ipcRenderer } from 'electron'
 const electronAPI = {
   platform: process.platform as 'darwin' | 'win32' | 'linux',
 
+  getVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
+
   openFolder: (): Promise<string | null> => ipcRenderer.invoke('dialog:openFolder'),
 
   readDirectory: (directoryPath: string): Promise<FileEntry[]> =>
@@ -82,6 +84,34 @@ const electronAPI = {
     }
     ipcRenderer.on('fs:change', handler)
     return () => ipcRenderer.removeListener('fs:change', handler)
+  },
+
+  checkForUpdates: (): Promise<void> => ipcRenderer.invoke('updater:checkForUpdates'),
+
+  quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updater:quitAndInstall'),
+
+  onUpdateAvailable: (callback: (info: UpdateEventInfo) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: UpdateEventInfo): void => {
+      callback(data)
+    }
+    ipcRenderer.on('updater:available', handler)
+    return () => ipcRenderer.removeListener('updater:available', handler)
+  },
+
+  onUpdateDownloaded: (callback: (info: UpdateEventInfo) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: UpdateEventInfo): void => {
+      callback(data)
+    }
+    ipcRenderer.on('updater:downloaded', handler)
+    return () => ipcRenderer.removeListener('updater:downloaded', handler)
+  },
+
+  onUpdateError: (callback: (info: UpdateErrorInfo) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: UpdateErrorInfo): void => {
+      callback(data)
+    }
+    ipcRenderer.on('updater:error', handler)
+    return () => ipcRenderer.removeListener('updater:error', handler)
   }
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from 'react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { AppShell } from '@/components/layout/AppShell'
+import { UpdateNotification } from '@/components/layout/UpdateNotification'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { useAppearanceStore } from '@/stores/appearance-store'
+import { useUpdateStore } from '@/stores/update-store'
 import { useAppearanceSystemListener } from '@/hooks/use-appearance-system-listener'
 import { useCourseManifestSync } from '@/hooks/use-course-manifest-sync'
 import { useCourseSidebarStore } from '@/stores/course-sidebar-store'
@@ -42,6 +44,26 @@ function App(): React.JSX.Element {
         useCourseSidebarStore.getState().hydrate(session.courseProjectFilesExpanded)
       }
     })
+  }, [])
+
+  useEffect(() => {
+    const { setAvailable, setDownloaded, setError } = useUpdateStore.getState()
+
+    const unsubAvailable = window.electronAPI.onUpdateAvailable((info) => {
+      setAvailable(info.version)
+    })
+    const unsubDownloaded = window.electronAPI.onUpdateDownloaded((info) => {
+      setDownloaded(info.version)
+    })
+    const unsubError = window.electronAPI.onUpdateError((info) => {
+      setError(info.message)
+    })
+
+    return () => {
+      unsubAvailable()
+      unsubDownloaded()
+      unsubError()
+    }
   }, [])
 
   useEffect(() => {
@@ -92,6 +114,7 @@ function App(): React.JSX.Element {
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <AppShell />
       </div>
+      <UpdateNotification />
     </TooltipProvider>
   )
 }

--- a/src/renderer/components/layout/UpdateNotification.tsx
+++ b/src/renderer/components/layout/UpdateNotification.tsx
@@ -1,0 +1,48 @@
+import { useUpdateStore } from '@/stores/update-store'
+import { Button } from '@/components/ui/button'
+import { Download, X } from 'lucide-react'
+
+export function UpdateNotification(): React.JSX.Element | null {
+  const status = useUpdateStore((s) => s.status)
+  const newVersion = useUpdateStore((s) => s.newVersion)
+  const dismissed = useUpdateStore((s) => s.dismissed)
+  const dismiss = useUpdateStore((s) => s.dismiss)
+
+  if (dismissed || (status !== 'downloading' && status !== 'ready')) return null
+
+  return (
+    <div className="fixed bottom-4 left-4 z-50 w-72 rounded-lg border bg-card p-3 shadow-lg">
+      <div className="flex items-start gap-2.5">
+        <Download className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-medium">
+            {status === 'downloading'
+              ? `Downloading v${newVersion}...`
+              : `Praxis v${newVersion} is ready`}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {status === 'downloading'
+              ? 'Downloading in the background.'
+              : 'Restart to apply the update.'}
+          </p>
+          {status === 'ready' && (
+            <div className="flex gap-2 pt-1">
+              <Button size="xs" onClick={() => window.electronAPI.quitAndInstall()}>
+                Restart now
+              </Button>
+              <Button size="xs" variant="ghost" onClick={dismiss}>
+                Later
+              </Button>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={dismiss}
+          className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/SettingsMenu.tsx
+++ b/src/renderer/components/settings/SettingsMenu.tsx
@@ -4,8 +4,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Separator } from '@/components/ui/separator'
 import { useAppearanceStore } from '@/stores/appearance-store'
+import { useUpdateStore } from '@/stores/update-store'
 import { cn } from '@/lib/utils'
-import { FolderOpen, RotateCcw, Settings } from 'lucide-react'
+import { FolderOpen, RefreshCw, RotateCcw, Settings } from 'lucide-react'
 
 const THEME_OPTIONS: Array<{ value: 'light' | 'dark' | 'system'; label: string }> = [
   { value: 'light', label: 'Light' },
@@ -32,6 +33,9 @@ export function SettingsMenu(): React.JSX.Element {
   const [reopenLastFolder, setReopenLastFolder] = useState(false)
   const [templatesDir, setTemplatesDir] = useState('')
   const [isCustomDir, setIsCustomDir] = useState(false)
+  const [appVersion, setAppVersion] = useState('')
+  const [checking, setChecking] = useState(false)
+  const updateStatus = useUpdateStore((s) => s.status)
 
   useEffect(() => {
     window.electronAPI.getSession().then((session) => {
@@ -39,6 +43,7 @@ export function SettingsMenu(): React.JSX.Element {
       setIsCustomDir(!!session.templatesDir)
     })
     window.electronAPI.getTemplatesDir().then(setTemplatesDir)
+    window.electronAPI.getVersion().then(setAppVersion)
   }, [])
 
   function handleReopenToggle(checked: boolean): void {
@@ -77,7 +82,7 @@ export function SettingsMenu(): React.JSX.Element {
           <Settings className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" side="bottom" className="w-[min(20rem,calc(100vw-2rem))] space-y-4 p-4">
+      <PopoverContent align="end" side="bottom" className="w-[min(20rem,calc(100vw-2rem))] max-h-[calc(100vh-5rem)] overflow-y-auto space-y-4 p-4">
         {/* ── Appearance ── */}
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Appearance</p>
@@ -213,9 +218,33 @@ export function SettingsMenu(): React.JSX.Element {
           </div>
         </div>
 
-        <p className="text-[10px] leading-relaxed text-muted-foreground/60">
-          All settings are saved automatically.
-        </p>
+        {/* ── About ── */}
+        <Separator />
+
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-[12px] text-muted-foreground">
+            Praxis v{appVersion}
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground"
+            disabled={checking || updateStatus === 'downloading' || updateStatus === 'ready'}
+            onClick={() => {
+              setChecking(true)
+              window.electronAPI.checkForUpdates().finally(() => setChecking(false))
+            }}
+          >
+            <RefreshCw className={cn('h-3 w-3', checking && 'animate-spin')} />
+            {updateStatus === 'ready'
+              ? 'Update ready'
+              : updateStatus === 'downloading'
+                ? 'Downloading…'
+                : checking
+                  ? 'Checking…'
+                  : 'Check for updates'}
+          </Button>
+        </div>
       </PopoverContent>
     </Popover>
   )

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -59,6 +59,15 @@ interface CourseProgress {
   completedLessons: string[]
 }
 
+interface UpdateEventInfo {
+  version: string
+  releaseNotes?: string
+}
+
+interface UpdateErrorInfo {
+  message: string
+}
+
 type ThemeMode = 'light' | 'dark' | 'system'
 type EditorFontPreset = 'system' | 'serif' | 'mono'
 
@@ -85,6 +94,7 @@ interface CourseTemplateMeta {
 
 interface ElectronAPI {
   platform: 'darwin' | 'win32' | 'linux'
+  getVersion: () => Promise<string>
   openFolder: () => Promise<string | null>
   readDirectory: (directoryPath: string) => Promise<FileEntry[]>
   readFile: (filePath: string) => Promise<string>
@@ -110,6 +120,11 @@ interface ElectronAPI {
   saveSession: (data: Partial<SessionData>) => Promise<void>
   setTitleBarOverlay: (options: { isDark: boolean }) => Promise<void>
   onFileSystemChange: (callback: (event: FileSystemChangeEvent) => void) => () => void
+  checkForUpdates: () => Promise<void>
+  quitAndInstall: () => Promise<void>
+  onUpdateAvailable: (callback: (info: UpdateEventInfo) => void) => () => void
+  onUpdateDownloaded: (callback: (info: UpdateEventInfo) => void) => () => void
+  onUpdateError: (callback: (info: UpdateErrorInfo) => void) => () => void
 }
 
 interface Window {

--- a/src/renderer/stores/update-store.ts
+++ b/src/renderer/stores/update-store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+type UpdateStatus = 'idle' | 'available' | 'downloading' | 'ready' | 'error'
+
+interface UpdateStore {
+  status: UpdateStatus
+  newVersion: string | null
+  errorMessage: string | null
+  dismissed: boolean
+  setAvailable: (version: string) => void
+  setDownloaded: (version: string) => void
+  setError: (message: string) => void
+  dismiss: () => void
+  reset: () => void
+}
+
+export const useUpdateStore = create<UpdateStore>()((set) => ({
+  status: 'idle',
+  newVersion: null,
+  errorMessage: null,
+  dismissed: false,
+
+  setAvailable: (version) => set({ status: 'downloading', newVersion: version, dismissed: false }),
+
+  setDownloaded: (version) => set({ status: 'ready', newVersion: version, dismissed: false }),
+
+  setError: (message) => set({ status: 'error', errorMessage: message }),
+
+  dismiss: () => set({ dismissed: true }),
+
+  reset: () => set({ status: 'idle', newVersion: null, errorMessage: null, dismissed: false })
+}))


### PR DESCRIPTION
## Summary
- Add auto-update functionality using `electron-updater` with GitHub Releases as the update provider
- Updates download in the background; a toast notification in the bottom-left prompts the user to restart when ready
- Add version display (`Praxis vX.Y.Z`) and "Check for updates" button in the settings popover
- Simplify CI release workflow: electron-builder now handles publishing directly (single job, `--publish always`, draft releases)
- Bump version to v0.2.0

## Changes
- **New**: `src/main/lib/auto-updater.ts` — electron-updater wrapper with event forwarding, 3s startup delay, 4h periodic checks
- **New**: `src/renderer/stores/update-store.ts` — zustand store for update state
- **New**: `src/renderer/components/layout/UpdateNotification.tsx` — floating toast notification
- **New**: `dev-app-update.yml` — local testing config (points updater at localhost:8080)
- **Modified**: `electron-builder.yml` — GitHub publish provider + `releaseType: draft`
- **Modified**: `.github/workflows/release.yml` — simplified to single build job
- **Modified**: Settings popover — scrollable, version + update check in About section

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm run lint` passes (no new warnings)
- [x] `npm run dev` starts without errors (updater skipped in dev mode)
- [x] Local update test: built v0.1.9 AppImage → served v0.2.0 on localhost → toast appeared → restart updated to v0.2.0
- [ ] CI: push a test tag to verify the workflow creates a draft release with all artifacts + `latest*.yml` manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)