### PR TITLE
v0.2.2: update UX polish + signing status docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.2.2 — Update UX Polish
+
+### New
+
+- **Manual "latest version" confirmation** — clicking "Check for updates" in the Settings menu now shows a toast confirming you're on the latest version when no update is available. Background checks remain silent.
+- **Explicit download step** — when an update is available, Praxis no longer starts downloading automatically. The update toast now shows a "Download" button so you control when the bits come down.
+- **Error visibility** — update failures now surface in the toast and (for manual checks) a transient error notification, instead of silently disappearing.
+
+### Improved
+
+- **Toast notifications** — added [Sonner](https://sonner.emilkowal.ski/) for transient success/error messages, themed to match the app's dark/light mode.
+- **Sticky "ready" state** — once an update is downloaded, a subsequent background check failure no longer clobbers the "Restart to install" toast.
+- **Updater diagnostics** — the main process now logs all updater events (`checking`, `available`, `not-available`, `download-progress`, `downloaded`, `error`) to make bug reports easier to triage.
+- **README: platform signing status** — documented the current code-signing state for macOS (ad-hoc today, Developer ID planned), Windows (unsigned by design), and Linux, plus what that means for auto-update on each platform.
+
+### Under the Hood
+
+- Removed unused `next-themes` and `lowlight` dependencies
+- New `updater:downloadUpdate` IPC handler and preload bridge method; new `updater:not-available` event
+- `UpdateNotification` rewritten as a 4-state component (available / downloading / ready / error)
+
+> **Heads up — macOS auto-update is still broken.** macOS Squirrel requires stable code-signing identity to verify updates, and the current ad-hoc signed builds get a fresh identity per build. This release is partly a validation: confirming that even universal-to-universal updates fail without proper Developer ID signing. A follow-up release will add Developer ID Application signing and fix the macOS auto-update pipeline end-to-end.
+
+---
+
 ## v0.2.1 — Icon & Universal Mac
 
 ### New

--- a/README.md
+++ b/README.md
@@ -206,3 +206,18 @@ npm run dev      # Start in development mode
 npm run build    # Build for production
 npm run lint     # Run ESLint
 ```
+
+## Installing & Updating
+
+Praxis ships for macOS (DMG, ZIP), Windows (NSIS installer), and Linux (AppImage, DEB). Grab the latest build from the [Releases](https://github.com/ttiimmaahh/praxis/releases) page.
+
+The macOS build is **universal** — a single DMG works on both Apple Silicon and Intel Macs.
+
+### Code signing
+
+| Platform | Signing | Auto-update |
+|----------|---------|-------------|
+| Windows  | **Unsigned** — SmartScreen will show a warning on first launch; click "More info" → "Run anyway". No plans to purchase a code-signing certificate. | Works out of the box. |
+| macOS    | **Unsigned (ad-hoc) today**, Developer ID signing planned for a future release. Gatekeeper may block launch; right-click → Open, or run `xattr -dr com.apple.quarantine /Applications/Praxis.app`. | **Broken on current builds.** macOS Squirrel requires stable code-signing identity to verify updates; ad-hoc signed builds get a fresh identity per build and fail the designated-requirement check. The in-app updater notice will appear but the install step will silently no-op. For now, download the new DMG manually from Releases. Will be fixed once Developer ID signing is wired in. |
+| Linux    | Unsigned. | Works via AppImage's built-in update mechanism where supported. |
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxis",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxis",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
@@ -39,7 +39,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "electron-updater": "^6.8.3",
-        "lowlight": "^3.3.0",
         "lucide-react": "^1.7.0",
         "platejs": "^52.3.21",
         "radix-ui": "^1.4.3",
@@ -49,6 +48,7 @@
         "react-dom": "^19.2.4",
         "react-resizable-panels": "^4.9.0",
         "shadcn": "^4.1.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tw-animate-css": "^1.4.0",
@@ -9822,15 +9822,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -10961,21 +10952,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lowlight": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
-      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.0.0",
-        "highlight.js": "~11.11.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -14612,6 +14588,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Desktop course authoring and learning platform for technical developer training",
   "author": {
     "name": "Tim Pearson",
@@ -55,7 +55,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "electron-updater": "^6.8.3",
-    "lowlight": "^3.3.0",
     "lucide-react": "^1.7.0",
     "platejs": "^52.3.21",
     "radix-ui": "^1.4.3",
@@ -65,6 +64,7 @@
     "react-dom": "^19.2.4",
     "react-resizable-panels": "^4.9.0",
     "shadcn": "^4.1.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwind-scrollbar-hide": "^4.0.0",
     "tw-animate-css": "^1.4.0",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { getTitleBarOverlayForIsDark } from './lib/title-bar-overlay'
-import { checkForUpdates, quitAndInstall } from './lib/auto-updater'
+import { checkForUpdates, downloadUpdate, quitAndInstall } from './lib/auto-updater'
 import {
   readDirectory,
   readFileContent,
@@ -198,6 +198,10 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('updater:checkForUpdates', async () => {
     await checkForUpdates()
+  })
+
+  ipcMain.handle('updater:downloadUpdate', async () => {
+    await downloadUpdate()
   })
 
   ipcMain.handle('updater:quitAndInstall', () => {

--- a/src/main/lib/auto-updater.ts
+++ b/src/main/lib/auto-updater.ts
@@ -15,22 +15,38 @@ export function initAutoUpdater(window: BrowserWindow): void {
 
   mainWindow = window
 
-  autoUpdater.autoDownload = true
+  // Manual download flow: the renderer decides when to actually pull bits
+  // so the user sees an explicit "Download" affordance in the update toast.
+  autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.logger = console
+
+  autoUpdater.on('checking-for-update', () => {
+    console.log('[auto-updater] checking for update')
+  })
 
   autoUpdater.on('update-available', (info: UpdateInfo) => {
+    console.log('[auto-updater] update available', info.version)
     sendToRenderer('updater:available', { version: info.version, releaseNotes: info.releaseNotes })
   })
 
+  autoUpdater.on('update-not-available', (info: UpdateInfo) => {
+    console.log('[auto-updater] update not available', info.version)
+    sendToRenderer('updater:not-available', { version: info.version })
+  })
+
   autoUpdater.on('download-progress', (progress) => {
+    console.log(`[auto-updater] download progress ${progress.percent.toFixed(1)}%`)
     sendToRenderer('updater:progress', { percent: progress.percent })
   })
 
   autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
+    console.log('[auto-updater] update downloaded', info.version)
     sendToRenderer('updater:downloaded', { version: info.version, releaseNotes: info.releaseNotes })
   })
 
   autoUpdater.on('error', (err: Error) => {
+    console.error('[auto-updater] error', err)
     sendToRenderer('updater:error', { message: err.message })
   })
 
@@ -43,6 +59,10 @@ export function initAutoUpdater(window: BrowserWindow): void {
 
 export function checkForUpdates(): Promise<void> {
   return autoUpdater.checkForUpdates().then(() => undefined)
+}
+
+export function downloadUpdate(): Promise<void> {
+  return autoUpdater.downloadUpdate().then(() => undefined)
 }
 
 export function quitAndInstall(): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -88,6 +88,8 @@ const electronAPI = {
 
   checkForUpdates: (): Promise<void> => ipcRenderer.invoke('updater:checkForUpdates'),
 
+  downloadUpdate: (): Promise<void> => ipcRenderer.invoke('updater:downloadUpdate'),
+
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updater:quitAndInstall'),
 
   onUpdateAvailable: (callback: (info: UpdateEventInfo) => void): (() => void) => {
@@ -96,6 +98,14 @@ const electronAPI = {
     }
     ipcRenderer.on('updater:available', handler)
     return () => ipcRenderer.removeListener('updater:available', handler)
+  },
+
+  onUpdateNotAvailable: (callback: (info: UpdateEventInfo) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: UpdateEventInfo): void => {
+      callback(data)
+    }
+    ipcRenderer.on('updater:not-available', handler)
+    return () => ipcRenderer.removeListener('updater:not-available', handler)
   },
 
   onUpdateDownloaded: (callback: (info: UpdateEventInfo) => void): (() => void) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { Toaster } from '@/components/ui/sonner'
 import { AppShell } from '@/components/layout/AppShell'
 import { UpdateNotification } from '@/components/layout/UpdateNotification'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -47,20 +49,39 @@ function App(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
-    const { setAvailable, setDownloaded, setError } = useUpdateStore.getState()
-
     const unsubAvailable = window.electronAPI.onUpdateAvailable((info) => {
+      const { setAvailable, manualCheckPending, setManualCheckPending } =
+        useUpdateStore.getState()
       setAvailable(info.version)
+      if (manualCheckPending) {
+        setManualCheckPending(false)
+      }
     })
+
+    const unsubNotAvailable = window.electronAPI.onUpdateNotAvailable(() => {
+      const { manualCheckPending, setManualCheckPending } = useUpdateStore.getState()
+      if (manualCheckPending) {
+        setManualCheckPending(false)
+        toast.success("You're on the latest version")
+      }
+    })
+
     const unsubDownloaded = window.electronAPI.onUpdateDownloaded((info) => {
-      setDownloaded(info.version)
+      useUpdateStore.getState().setDownloaded(info.version)
     })
+
     const unsubError = window.electronAPI.onUpdateError((info) => {
+      const { setError, manualCheckPending, setManualCheckPending } = useUpdateStore.getState()
       setError(info.message)
+      if (manualCheckPending) {
+        setManualCheckPending(false)
+        toast.error('Update check failed', { description: info.message })
+      }
     })
 
     return () => {
       unsubAvailable()
+      unsubNotAvailable()
       unsubDownloaded()
       unsubError()
     }
@@ -115,6 +136,7 @@ function App(): React.JSX.Element {
         <AppShell />
       </div>
       <UpdateNotification />
+      <Toaster position="bottom-right" />
     </TooltipProvider>
   )
 }

--- a/src/renderer/components/layout/UpdateNotification.tsx
+++ b/src/renderer/components/layout/UpdateNotification.tsx
@@ -1,44 +1,88 @@
 import { useUpdateStore } from '@/stores/update-store'
 import { Button } from '@/components/ui/button'
-import { Download, X } from 'lucide-react'
+import { AlertTriangle, Download, X } from 'lucide-react'
 
 export function UpdateNotification(): React.JSX.Element | null {
   const status = useUpdateStore((s) => s.status)
   const newVersion = useUpdateStore((s) => s.newVersion)
+  const errorMessage = useUpdateStore((s) => s.errorMessage)
   const dismissed = useUpdateStore((s) => s.dismissed)
+  const startDownload = useUpdateStore((s) => s.startDownload)
   const dismiss = useUpdateStore((s) => s.dismiss)
 
-  if (dismissed || (status !== 'downloading' && status !== 'ready')) return null
+  if (dismissed) return null
+  if (status !== 'available' && status !== 'downloading' && status !== 'ready' && status !== 'error') {
+    return null
+  }
+
+  const handleDownload = (): void => {
+    startDownload()
+    window.electronAPI.downloadUpdate().catch((err) => {
+      console.error('[updater] downloadUpdate failed', err)
+    })
+  }
 
   return (
     <div className="fixed bottom-4 left-4 z-50 w-72 rounded-lg border bg-card p-3 shadow-lg">
       <div className="flex items-start gap-2.5">
-        <Download className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        {status === 'error' ? (
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        ) : (
+          <Download className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        )}
         <div className="flex-1 space-y-1">
-          <p className="text-sm font-medium">
-            {status === 'downloading'
-              ? `Downloading v${newVersion}...`
-              : `Praxis v${newVersion} is ready`}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {status === 'downloading'
-              ? 'Downloading in the background.'
-              : 'Restart to apply the update.'}
-          </p>
+          {status === 'available' && (
+            <>
+              <p className="text-sm font-medium">Praxis v{newVersion} is available</p>
+              <p className="text-xs text-muted-foreground">
+                Download now, then restart when you&apos;re ready.
+              </p>
+              <div className="flex gap-2 pt-1">
+                <Button size="xs" onClick={handleDownload}>
+                  Download
+                </Button>
+                <Button size="xs" variant="ghost" onClick={dismiss}>
+                  Later
+                </Button>
+              </div>
+            </>
+          )}
+
+          {status === 'downloading' && (
+            <>
+              <p className="text-sm font-medium">Downloading v{newVersion}…</p>
+              <p className="text-xs text-muted-foreground">Downloading in the background.</p>
+            </>
+          )}
+
           {status === 'ready' && (
-            <div className="flex gap-2 pt-1">
-              <Button size="xs" onClick={() => window.electronAPI.quitAndInstall()}>
-                Restart now
-              </Button>
-              <Button size="xs" variant="ghost" onClick={dismiss}>
-                Later
-              </Button>
-            </div>
+            <>
+              <p className="text-sm font-medium">Praxis v{newVersion} is ready</p>
+              <p className="text-xs text-muted-foreground">Restart to apply the update.</p>
+              <div className="flex gap-2 pt-1">
+                <Button size="xs" onClick={() => window.electronAPI.quitAndInstall()}>
+                  Restart now
+                </Button>
+                <Button size="xs" variant="ghost" onClick={dismiss}>
+                  Later
+                </Button>
+              </div>
+            </>
+          )}
+
+          {status === 'error' && (
+            <>
+              <p className="text-sm font-medium">Update failed</p>
+              <p className="text-xs break-words text-muted-foreground">
+                {errorMessage ?? 'An unknown error occurred while updating.'}
+              </p>
+            </>
           )}
         </div>
         <button
           onClick={dismiss}
           className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Dismiss"
         >
           <X className="size-3.5" />
         </button>

--- a/src/renderer/components/settings/SettingsMenu.tsx
+++ b/src/renderer/components/settings/SettingsMenu.tsx
@@ -229,9 +229,15 @@ export function SettingsMenu(): React.JSX.Element {
             variant="ghost"
             size="sm"
             className="h-7 gap-1.5 text-xs text-muted-foreground"
-            disabled={checking || updateStatus === 'downloading' || updateStatus === 'ready'}
+            disabled={
+              checking ||
+              updateStatus === 'available' ||
+              updateStatus === 'downloading' ||
+              updateStatus === 'ready'
+            }
             onClick={() => {
               setChecking(true)
+              useUpdateStore.getState().setManualCheckPending(true)
               window.electronAPI.checkForUpdates().finally(() => setChecking(false))
             }}
           >
@@ -240,9 +246,11 @@ export function SettingsMenu(): React.JSX.Element {
               ? 'Update ready'
               : updateStatus === 'downloading'
                 ? 'Downloading…'
-                : checking
-                  ? 'Checking…'
-                  : 'Check for updates'}
+                : updateStatus === 'available'
+                  ? 'Update available'
+                  : checking
+                    ? 'Checking…'
+                    : 'Check for updates'}
           </Button>
         </div>
       </PopoverContent>

--- a/src/renderer/components/ui/sonner.tsx
+++ b/src/renderer/components/ui/sonner.tsx
@@ -1,0 +1,37 @@
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from 'lucide-react'
+import { useDocumentIsDark } from '@/hooks/use-document-is-dark'
+
+const Toaster = ({ ...props }: ToasterProps): React.JSX.Element => {
+  const isDark = useDocumentIsDark()
+
+  return (
+    <Sonner
+      theme={isDark ? 'dark' : 'light'}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />
+      }}
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)'
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: 'cn-toast'
+        }
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -77,8 +77,10 @@ interface ElectronAPI {
   setTitleBarOverlay: (options: { isDark: boolean }) => Promise<void>
   onFileSystemChange: (callback: (event: FileSystemChangeEvent) => void) => () => void
   checkForUpdates: () => Promise<void>
+  downloadUpdate: () => Promise<void>
   quitAndInstall: () => Promise<void>
   onUpdateAvailable: (callback: (info: UpdateEventInfo) => void) => () => void
+  onUpdateNotAvailable: (callback: (info: UpdateEventInfo) => void) => () => void
   onUpdateDownloaded: (callback: (info: UpdateEventInfo) => void) => () => void
   onUpdateError: (callback: (info: UpdateErrorInfo) => void) => () => void
 }

--- a/src/renderer/stores/update-store.ts
+++ b/src/renderer/stores/update-store.ts
@@ -7,7 +7,15 @@ interface UpdateStore {
   newVersion: string | null
   errorMessage: string | null
   dismissed: boolean
+  /**
+   * Set when the user explicitly clicked "Check for updates" in Settings.
+   * Consumed by the `update-not-available` handler to show a "you're on the
+   * latest version" toast — background periodic checks should stay silent.
+   */
+  manualCheckPending: boolean
+  setManualCheckPending: (pending: boolean) => void
   setAvailable: (version: string) => void
+  startDownload: () => void
   setDownloaded: (version: string) => void
   setError: (message: string) => void
   dismiss: () => void
@@ -19,14 +27,34 @@ export const useUpdateStore = create<UpdateStore>()((set) => ({
   newVersion: null,
   errorMessage: null,
   dismissed: false,
+  manualCheckPending: false,
 
-  setAvailable: (version) => set({ status: 'downloading', newVersion: version, dismissed: false }),
+  setManualCheckPending: (pending) => set({ manualCheckPending: pending }),
 
-  setDownloaded: (version) => set({ status: 'ready', newVersion: version, dismissed: false }),
+  setAvailable: (version) =>
+    set({ status: 'available', newVersion: version, errorMessage: null, dismissed: false }),
 
-  setError: (message) => set({ status: 'error', errorMessage: message }),
+  startDownload: () => set({ status: 'downloading', dismissed: false }),
+
+  setDownloaded: (version) =>
+    set({ status: 'ready', newVersion: version, errorMessage: null, dismissed: false }),
+
+  // Don't clobber a ready state — once an update is downloaded it stays ready
+  // even if a later background check fails. Errors only show when we're not
+  // already sitting on a usable download.
+  setError: (message) =>
+    set((s) =>
+      s.status === 'ready' ? s : { status: 'error', errorMessage: message, dismissed: false }
+    ),
 
   dismiss: () => set({ dismissed: true }),
 
-  reset: () => set({ status: 'idle', newVersion: null, errorMessage: null, dismissed: false })
+  reset: () =>
+    set({
+      status: 'idle',
+      newVersion: null,
+      errorMessage: null,
+      dismissed: false,
+      manualCheckPending: false
+    })
 }))


### PR DESCRIPTION
## Summary

- Rework the update flow: `autoDownload=false` so users click an explicit **Download** button before any bytes move; added "you're on the latest version" toast on manual check; surfaced update errors in the notification and in toast form.
- Ship shadcn **Sonner** for transient toasts, wired to the app's own theme classes (no `next-themes` dep).
- Preserve `ready` state across later background failures so a subsequent error check can no longer clobber a pending "Restart to install" prompt.
- Add verbose updater diagnostics (`console.log`/`console.error` on every event) to make bug reports easier to triage.
- Document macOS/Windows/Linux signing status and auto-update caveats in the README. **macOS auto-update remains broken until Developer ID signing lands** — this release is partly a validation that even universal→universal updates fail without a stable signing identity.
- Drop unused `next-themes` and `lowlight` dependencies.

## Test plan

- [x] `npx tsc -p tsconfig.node.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.web.json --noEmit` — only the 2 pre-existing Plate.js errors in `MarkdownEditor.tsx` / `font-color-toolbar-button.tsx`
- [x] `npm test` — 40/40 pass
- [x] `npm run build` — clean
- [x] Manual: `npm run dev` — confirmed toaster mounts, theme follows dark/light
- [ ] After merge + tag: install the v0.2.1 build, trigger update, verify:
  - Windows: "Download" button appears → restart toast appears → restart installs v0.2.2
  - macOS: expected to fail install (validating the signing theory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)