### PR TITLE
ci: auto-populate release notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,33 @@ jobs:
         run: npx electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-notes:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate tag format
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "error: tag '$TAG' does not match expected vMAJOR.MINOR.PATCH format" >&2
+            exit 1
+          fi
+
+      - name: Build release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: ./scripts/build-release-notes.sh "$TAG" > release-notes.md
+
+      - name: Apply release notes to draft release
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md

--- a/scripts/build-release-notes.sh
+++ b/scripts/build-release-notes.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Extracts the CHANGELOG.md section for the given version and appends the
+# standard Download block + Full Changelog link, printing the result to stdout.
+#
+# Usage:
+#   scripts/build-release-notes.sh v0.2.2 > notes.md
+#   scripts/build-release-notes.sh v0.2.2 v0.2.1   # explicit previous tag
+#
+# The previous tag is optional — if omitted, the Full Changelog link points
+# to the closest prior section heading in CHANGELOG.md.
+
+set -euo pipefail
+
+TAG="${1:-}"
+PREV_TAG="${2:-}"
+
+if [[ -z "$TAG" ]]; then
+  echo "error: tag argument required (e.g. v0.2.2)" >&2
+  exit 1
+fi
+
+# Strip leading "v" for bare version (0.2.2) used in artifact filenames.
+VERSION="${TAG#v}"
+
+CHANGELOG="$(dirname "$0")/../CHANGELOG.md"
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "error: CHANGELOG.md not found at $CHANGELOG" >&2
+  exit 1
+fi
+
+# Extract the section for the matching version heading. The CHANGELOG uses
+# "## v0.2.2 — Update UX Polish" style headings, so we match on the literal
+# "## v<version>" prefix and stop at the next "## v" heading.
+SECTION="$(awk -v tag="$TAG" '
+  BEGIN { inside = 0 }
+  /^## v/ {
+    if (inside) { exit }
+    if ($2 == tag) { inside = 1; print; next }
+  }
+  inside { print }
+' "$CHANGELOG")"
+
+if [[ -z "$SECTION" ]]; then
+  echo "error: no CHANGELOG.md section found for $TAG" >&2
+  echo "hint: make sure there is a '## $TAG — Title' heading in CHANGELOG.md" >&2
+  exit 1
+fi
+
+# Trim the trailing "---" separator (if present) and any trailing blank lines.
+SECTION="$(printf '%s\n' "$SECTION" | awk '
+  { lines[NR] = $0 }
+  END {
+    end = NR
+    # Walk backwards, dropping blank lines and a trailing "---" separator.
+    while (end > 0 && lines[end] ~ /^[[:space:]]*$/) { end-- }
+    if (end > 0 && lines[end] == "---") { end-- }
+    while (end > 0 && lines[end] ~ /^[[:space:]]*$/) { end-- }
+    for (i = 1; i <= end; i++) { print lines[i] }
+  }
+')"
+
+# Resolve the previous tag for the Full Changelog link. If not provided, fall
+# back to the next "## v" heading below the current one in CHANGELOG.md. If
+# that's also missing (first release), omit the link.
+if [[ -z "$PREV_TAG" ]]; then
+  PREV_TAG="$(awk -v tag="$TAG" '
+    BEGIN { passed = 0 }
+    /^## v/ {
+      if (passed) { print $2; exit }
+      if ($2 == tag) { passed = 1 }
+    }
+  ' "$CHANGELOG")"
+fi
+
+# Emit the final notes.
+printf '%s\n\n' "$SECTION"
+
+cat <<EOF
+### Download
+
+- **macOS (Apple Silicon & Intel)** — \`praxis-${VERSION}-universal.dmg\` or \`praxis-${VERSION}-universal.zip\`
+- **Windows** — \`praxis-${VERSION}-setup.exe\`
+- **Linux** — \`praxis-${VERSION}-x86_64.AppImage\` or \`praxis-${VERSION}-amd64.deb\`
+EOF
+
+if [[ -n "$PREV_TAG" ]]; then
+  printf '\n**Full Changelog**: https://github.com/ttiimmaahh/praxis/compare/%s...%s\n' "$PREV_TAG" "$TAG"
+fi


### PR DESCRIPTION
## Summary

Adds a `release-notes` job to the release workflow that runs after the build matrix and:

1. Extracts the `## v<version>` section from `CHANGELOG.md` for the current tag
2. Appends the standard **Download** block (macOS/Windows/Linux artifact filenames) and a **Full Changelog** compare link
3. Applies the result to the draft release that electron-builder just created, via `gh release edit --notes-file`

The draft stays as a draft — electron-builder was already configured with `releaseType: draft` — so the human still clicks "Publish" after reviewing. This just removes the manual `gh release edit` step we hit on every release.

### Why this shape

- **Hand-written CHANGELOG remains the source of truth.** No conventional-commits coercion, no release-please/changesets bot — we keep the narrative CHANGELOG prose we've been writing.
- **Small awk extractor** (`scripts/build-release-notes.sh`) is testable locally with no CI round trip. Fails loudly with a helpful hint if the CHANGELOG is missing a matching section.
- **Workflow safety**: explicit `env:` mappings for `github.ref_name` + a tag-format guard (`vMAJOR.MINOR.PATCH[-prerelease]`) to avoid workflow-injection patterns.

### Test plan

- [x] Local dry-run against `v0.2.2` matches the notes we published by hand
- [x] Local dry-run against `v0.2.1` produces correct output (uses CHANGELOG fallback to derive previous tag)
- [x] Error path: `v9.9.9` fails with a helpful message
- [x] Error path: no args fails with usage
- [ ] End-to-end: validated on the next real release (v0.2.3 / whichever comes next). If it fails at the notes step, artifacts will still be in the draft — we can re-run the failed job after fixing `CHANGELOG.md`.

### Follow-up (not in this PR)

- Optional CI-side pre-check: fail a PR if `package.json` version bumped but `CHANGELOG.md` has no matching section. Skipped here to keep scope tight; easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)