### PR TITLE
chore: sign and notarize macOS builds with Developer ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
         run: npx electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   release-notes:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.2.3 — Signed & Notarized macOS Builds
+
+### New
+
+- **macOS code signing** — Praxis is now signed with a Developer ID Application certificate and notarized by Apple. Gatekeeper opens the app cleanly on first launch — no more right-click-Open or `xattr` workaround.
+- **macOS auto-update works** — with a stable code-signing identity in place, Squirrel.Mac can now verify updates against the running app's Designated Requirement. v0.2.3 → v0.2.4 and every subsequent release will auto-update on macOS.
+
+### Fixed
+
+- **Silent auto-update failures on macOS** — previous ad-hoc signed builds produced a fresh random identity per build, so Squirrel.Mac refused to install any update. This is resolved for all releases starting with v0.2.3.
+
+### Heads up — one-time manual install required
+
+Because v0.2.2 and earlier were ad-hoc signed, the running app on your machine cannot verify v0.2.3 against its own Designated Requirement — the in-app updater will not be able to bridge this release. **Download the v0.2.3 DMG manually from the [Releases](https://github.com/ttiimmaahh/praxis/releases) page and install over your existing copy.** Every release after v0.2.3 will auto-update normally.
+
+### Under the Hood
+
+- `electron-builder.yml` — enabled `hardenedRuntime`, `notarize: true`, and wired a new `build/entitlements.mac.plist` granting the JIT / unsigned-executable-memory / library-validation exceptions Electron's V8 needs.
+- `.github/workflows/release.yml` — pipes `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID` into the `electron-builder` step on the macOS runner. Windows and Linux jobs ignore these env vars and continue to ship unsigned as before.
+
+---
+
 ## v0.2.2 — Update UX Polish
 
 ### New

--- a/README.md
+++ b/README.md
@@ -218,6 +218,6 @@ The macOS build is **universal** — a single DMG works on both Apple Silicon an
 | Platform | Signing | Auto-update |
 |----------|---------|-------------|
 | Windows  | **Unsigned** — SmartScreen will show a warning on first launch; click "More info" → "Run anyway". No plans to purchase a code-signing certificate. | Works out of the box. |
-| macOS    | **Unsigned (ad-hoc) today**, Developer ID signing planned for a future release. Gatekeeper may block launch; right-click → Open, or run `xattr -dr com.apple.quarantine /Applications/Praxis.app`. | **Broken on current builds.** macOS Squirrel requires stable code-signing identity to verify updates; ad-hoc signed builds get a fresh identity per build and fail the designated-requirement check. The in-app updater notice will appear but the install step will silently no-op. For now, download the new DMG manually from Releases. Will be fixed once Developer ID signing is wired in. |
+| macOS    | **Signed with Developer ID Application & notarized by Apple** (v0.2.3+). Opens cleanly via Gatekeeper on first launch. | **Works** for v0.2.3 and later. Updating from v0.2.2 or earlier (unsigned) to v0.2.3 requires a one-time manual download from Releases — Squirrel.Mac cannot bridge the identity change from ad-hoc to Developer ID. Every subsequent release auto-updates normally. |
 | Linux    | Unsigned. | Works via AppImage's built-in update mechanism where supported. |
 

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,6 +17,12 @@ mac:
     - target: zip
       arch: universal
   artifactName: ${name}-${version}-${arch}.${ext}
+  category: public.app-category.education
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
 win:
   target:
     - nsis


### PR DESCRIPTION
## Summary

- Enables Developer ID Application signing + Apple notarization for macOS builds, unblocking macOS auto-update which has been broken since v0.2.0
- Adds a minimal hardened-runtime entitlements plist granting the V8 JIT / library-validation exceptions Electron needs to launch under a signed, notarized bundle
- Wires the `CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` repo secrets into `release.yml` so the macOS runner can sign + notarize in CI (Windows/Linux runners ignore empty values)

### Why auto-update was broken

electron-updater on macOS uses Squirrel.Mac, which verifies updates against the running app's code-signing Designated Requirement. Ad-hoc signed builds (`codesign -s -`, which is what electron-builder produced in CI with no `CSC_LINK`) get a fresh random identity per build, so every new build failed the DR check and Squirrel silently refused to install. Confirmed end-to-end with v0.2.1 → v0.2.2 on 2026-04-09. Fix is to sign with a stable Developer ID identity, which produces a stable DR anchor.

## Heads up — one-time manual install required

This PR cannot fix the v0.2.2 → v0.2.3 update path for existing users, because the running v0.2.2 is checking its own (ad-hoc) Designated Requirement against the new (Developer ID) build. Users on v0.2.2 will need to **manually download and install v0.2.3** from the Releases page. Every release from v0.2.3 onward will auto-update cleanly.

CHANGELOG and README are updated to document this caveat.

## Test plan

- [ ] Repo secrets confirmed present with exact names: `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`
- [ ] Merge, then tag `v0.2.3` and push the tag to trigger the release workflow
- [ ] Watch the macOS job logs for `identityName=Developer ID Application: Tim Pearson (...)` (NOT `adhoc`) and `notarization successful`
- [ ] Download the draft release's DMG manually, install over v0.2.2
- [ ] `codesign -dv --verbose=4 /Applications/Praxis.app` shows `Authority=Developer ID Application: Tim Pearson (...)`
- [ ] `spctl -a -vv /Applications/Praxis.app` shows `accepted  source=Notarized Developer ID`
- [ ] App launches cleanly — no right-click-Open, no Gatekeeper prompt
- [ ] Publish v0.2.3, then cut v0.2.4 (trivial change) as the real auto-update validation: v0.2.3 → v0.2.4 must actually install via the in-app updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)