### PR TITLE
Fix markdown table rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.2.5 — Markdown Table Rendering
+
+### Fixed
+
+- **Course Markdown tables now render as tables** — enabled GitHub Flavored Markdown parsing in the shared Plate markdown pipeline, so pipe tables in lessons no longer appear as raw `|`-delimited text.
+- **Learner table layout is more readable** — read-only/course tables now use markdown-viewer-style fluid sizing instead of the editor's fixed-width resize columns, avoiding cramped 120px columns and unnecessary horizontal scrollbars for normal tables.
+
+### Under the Hood
+
+- Added `remark-gfm` and configured `MarkdownPlugin` with `remarkPlugins: [remarkGfm]`.
+- `LessonReader` now reuses `getSharedPlatePlugins({ includeDnd: false })`, keeping learner rendering aligned with the editor/export plugin pipeline.
+- Added a regression test covering GFM pipe-table deserialization into Plate table nodes.
+
+---
+
 ## v0.2.4 — Document & Course Export
 
 Praxis can now export your work to HTML and PDF — whether it's a single Markdown file or an entire course.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxis",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxis",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
@@ -47,6 +47,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.2.4",
         "react-resizable-panels": "^4.9.0",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -11005,6 +11006,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -11039,6 +11050,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -11057,6 +11096,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11310,6 +11450,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -13576,6 +13837,24 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-mdx": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Desktop course authoring and learning platform for technical developer training",
   "author": {
     "name": "Tim Pearson",
@@ -63,6 +63,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.2.4",
     "react-resizable-panels": "^4.9.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/src/renderer/components/learner/LessonReader.tsx
+++ b/src/renderer/components/learner/LessonReader.tsx
@@ -1,50 +1,9 @@
 import { useRef } from 'react'
-import {
-  BlockquotePlugin,
-  BoldPlugin,
-  CodePlugin,
-  H1Plugin,
-  H2Plugin,
-  H3Plugin,
-  H4Plugin,
-  H5Plugin,
-  H6Plugin,
-  HorizontalRulePlugin,
-  ItalicPlugin,
-  StrikethroughPlugin,
-} from '@platejs/basic-nodes/react'
-import { CodeBlockPlugin, CodeLinePlugin, CodeSyntaxPlugin } from '@platejs/code-block/react'
-import { LinkPlugin } from '@platejs/link/react'
-import { ImagePlugin } from '@platejs/media/react'
-import {
-  BulletedListPlugin,
-  ListItemPlugin,
-  ListPlugin,
-  NumberedListPlugin,
-  TaskListPlugin,
-} from '@platejs/list-classic/react'
-import {
-  TableCellHeaderPlugin,
-  TableCellPlugin,
-  TablePlugin,
-  TableRowPlugin,
-} from '@platejs/table/react'
 import { MarkdownPlugin } from '@platejs/markdown'
 import { Plate, usePlateEditor } from 'platejs/react'
+
+import { getSharedPlatePlugins } from '@/lib/plate-plugins'
 import { Editor, EditorContainer } from '@/components/ui/editor'
-import { H1Element, H2Element, H3Element, H4Element, H5Element, H6Element } from '@/components/ui/heading-node'
-import { BlockquoteElement } from '@/components/ui/blockquote-node'
-import { CodeBlockElement, CodeLineElement, CodeSyntaxLeaf } from '@/components/ui/code-block-node'
-import { LinkElement } from '@/components/ui/link-node'
-import { ImageElement } from '@/components/ui/image-node'
-import { HrElement } from '@/components/ui/hr-node'
-import {
-  BulletedListElement,
-  ListItemElement,
-  NumberedListElement,
-  TaskListElement,
-} from '@/components/ui/list-classic-node'
-import { TableElement, TableCellElement, TableCellHeaderElement, TableRowElement } from '@/components/ui/table-node'
 
 interface LessonReaderProps {
   content: string
@@ -55,36 +14,8 @@ export function LessonReader({ content }: LessonReaderProps): React.JSX.Element 
 
   const editor = usePlateEditor(
     {
-      plugins: [
-        BoldPlugin,
-        ItalicPlugin,
-        StrikethroughPlugin,
-        CodePlugin,
-        H1Plugin.withComponent(H1Element),
-        H2Plugin.withComponent(H2Element),
-        H3Plugin.withComponent(H3Element),
-        H4Plugin.withComponent(H4Element),
-        H5Plugin.withComponent(H5Element),
-        H6Plugin.withComponent(H6Element),
-        BlockquotePlugin.withComponent(BlockquoteElement),
-        HorizontalRulePlugin.withComponent(HrElement),
-        CodeBlockPlugin.withComponent(CodeBlockElement),
-        CodeLinePlugin.withComponent(CodeLineElement),
-        CodeSyntaxPlugin.withComponent(CodeSyntaxLeaf),
-        LinkPlugin.withComponent(LinkElement),
-        ImagePlugin.withComponent(ImageElement),
-        ListPlugin,
-        BulletedListPlugin.withComponent(BulletedListElement),
-        NumberedListPlugin.withComponent(NumberedListElement),
-        TaskListPlugin.withComponent(TaskListElement),
-        ListItemPlugin.withComponent(ListItemElement),
-        TablePlugin.configure({ node: { component: TableElement } }),
-        TableRowPlugin.withComponent(TableRowElement),
-        TableCellPlugin.withComponent(TableCellElement),
-        TableCellHeaderPlugin.withComponent(TableCellHeaderElement),
-        MarkdownPlugin,
-      ],
-      value: (editor) => editor.getApi(MarkdownPlugin).markdown.deserialize(contentRef.current),
+      plugins: getSharedPlatePlugins({ includeDnd: false }),
+      value: (editor) => editor.getApi(MarkdownPlugin).markdown.deserialize(contentRef.current)
     },
     []
   )

--- a/src/renderer/components/ui/table-node.tsx
+++ b/src/renderer/components/ui/table-node.tsx
@@ -648,7 +648,7 @@ export const TableElement = withHOC(
       );
     }, [colSizes, props.element]);
     const tableVariableStyle = React.useMemo(() => {
-      if (resolvedColSizes.length === 0) {
+      if (readOnly || resolvedColSizes.length === 0) {
         return;
       }
 
@@ -660,17 +660,19 @@ export const TableElement = withHOC(
           ])
         ),
       } as React.CSSProperties;
-    }, [resolvedColSizes]);
-    const tableStyle = React.useMemo(
-      () =>
-        ({
-          width: `${
-            resolvedColSizes.reduce((total, colSize) => total + colSize, 0) +
-            controlColumnWidth
-          }px`,
-        }) as React.CSSProperties,
-      [controlColumnWidth, resolvedColSizes]
-    );
+    }, [readOnly, resolvedColSizes]);
+    const tableStyle = React.useMemo(() => {
+      if (readOnly) {
+        return;
+      }
+
+      return {
+        width: `${
+          resolvedColSizes.reduce((total, colSize) => total + colSize, 0) +
+          controlColumnWidth
+        }px`,
+      } as React.CSSProperties;
+    }, [controlColumnWidth, readOnly, resolvedColSizes]);
 
     const isSelectingTable = useBlockSelected(props.element.id as string);
 
@@ -678,7 +680,8 @@ export const TableElement = withHOC(
       <PlateElement
         {...props}
         className={cn(
-          'overflow-x-auto py-5',
+          'py-5',
+          readOnly ? 'overflow-x-hidden' : 'overflow-x-auto',
           hasControls && '-ml-2 *:data-[slot=block-selection]:left-2'
         )}
         style={{ paddingLeft: marginLeft }}
@@ -686,7 +689,7 @@ export const TableElement = withHOC(
         <TableResizeContext.Provider value={resizeController}>
           <div
             ref={wrapperRef}
-            className="group/table relative w-fit"
+            className={cn('group/table relative', readOnly ? 'w-full' : 'w-fit')}
             style={tableVariableStyle}
           >
             <div
@@ -702,7 +705,8 @@ export const TableElement = withHOC(
             <table
               ref={tableRef}
               className={cn(
-                'mr-0 ml-px table h-px table-fixed border-collapse',
+                'table h-px border-collapse',
+                readOnly ? 'mx-0 w-[calc(100%-2px)] table-auto text-sm' : 'mr-0 ml-px table-fixed',
                 'data-[table-selecting=true]:[&_*::selection]:!bg-transparent',
                 'data-[table-selecting=true]:[&_*::selection]:!text-inherit',
                 'data-[table-selecting=true]:[&_*::-moz-selection]:!bg-transparent',
@@ -712,7 +716,7 @@ export const TableElement = withHOC(
               style={tableStyle}
               {...tableProps}
             >
-              {resolvedColSizes.length > 0 && (
+              {!readOnly && resolvedColSizes.length > 0 && (
                 <colgroup>
                   {hasControls && (
                     <col
@@ -1297,13 +1301,20 @@ export function TableCellElement({
 
   const { borders, colIndex, colSpan, rowIndex, rowSpan, width } =
     useTableCellPresentation(element);
+  const cellSizingStyle = readOnly
+    ? undefined
+    : ({
+        maxWidth: width,
+        minWidth: width,
+      } as React.CSSProperties);
 
   return (
     <PlateElement
       {...props}
       as={isHeader ? 'th' : 'td'}
       className={cn(
-        'relative h-full overflow-visible border-none bg-background p-0',
+        'relative h-full overflow-visible bg-background p-0 align-top',
+        readOnly ? 'border border-border/70' : 'border-none',
         element.background ? 'bg-(--cellBackground)' : 'bg-background',
         isHeader && 'text-left *:m-0',
         'before:size-full',
@@ -1318,8 +1329,7 @@ export function TableCellElement({
       style={
         {
           '--cellBackground': element.background,
-          maxWidth: width,
-          minWidth: width,
+          ...cellSizingStyle,
         } as React.CSSProperties
       }
       attributes={{
@@ -1330,7 +1340,10 @@ export function TableCellElement({
       }}
     >
       <div
-        className="relative z-20 box-border h-full px-3 py-2"
+        className={cn(
+          'relative z-20 box-border h-full px-3 py-2',
+          readOnly && 'whitespace-normal break-normal leading-relaxed'
+        )}
         style={
           rowSpan === 1
             ? { minHeight: 'var(--tableRowMinHeight, 0px)' }

--- a/src/renderer/lib/plate-plugins.test.ts
+++ b/src/renderer/lib/plate-plugins.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createPlateEditor } from 'platejs/react'
+import { MarkdownPlugin } from '@platejs/markdown'
+
+import { getSharedPlatePlugins } from './plate-plugins'
+
+const tableMarkdown = `| Role | What it is | What you care about as a server author |
+|---|---|---|
+| Host | The user-facing LLM application | User experience |
+| MCP client | The connector inside the host | Protocol support |
+| MCP server | Your program | Capability design |`
+
+describe('getSharedPlatePlugins', () => {
+  it('deserializes GitHub Flavored Markdown tables into Plate tables', () => {
+    const editor = createPlateEditor({
+      plugins: getSharedPlatePlugins({ includeDnd: false })
+    })
+
+    const value = editor.getApi(MarkdownPlugin).markdown.deserialize(tableMarkdown)
+
+    expect(value[0]?.type).toBe('table')
+    expect(value[0]?.children).toHaveLength(4)
+    expect(value[0]?.children[0]).toMatchObject({
+      type: 'tr',
+      children: [
+        { type: 'th', children: [{ type: 'p', children: [{ text: 'Role' }] }] },
+        { type: 'th', children: [{ type: 'p', children: [{ text: 'What it is' }] }] },
+        {
+          type: 'th',
+          children: [{ type: 'p', children: [{ text: 'What you care about as a server author' }] }]
+        }
+      ]
+    })
+  })
+})

--- a/src/renderer/lib/plate-plugins.tsx
+++ b/src/renderer/lib/plate-plugins.tsx
@@ -10,7 +10,7 @@ import {
   H6Plugin,
   HorizontalRulePlugin,
   ItalicPlugin,
-  StrikethroughPlugin,
+  StrikethroughPlugin
 } from '@platejs/basic-nodes/react'
 import { CodeBlockPlugin, CodeLinePlugin, CodeSyntaxPlugin } from '@platejs/code-block/react'
 import { LinkPlugin } from '@platejs/link/react'
@@ -20,26 +20,34 @@ import {
   ListItemPlugin,
   ListPlugin,
   NumberedListPlugin,
-  TaskListPlugin,
+  TaskListPlugin
 } from '@platejs/list-classic/react'
 import {
   TableCellHeaderPlugin,
   TableCellPlugin,
   TablePlugin,
-  TableRowPlugin,
+  TableRowPlugin
 } from '@platejs/table/react'
 import { MarkdownPlugin } from '@platejs/markdown'
 import { DndPlugin } from '@platejs/dnd'
+import remarkGfm from 'remark-gfm'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 
-import { H1Element, H2Element, H3Element, H4Element, H5Element, H6Element } from '@/components/ui/heading-node'
+import {
+  H1Element,
+  H2Element,
+  H3Element,
+  H4Element,
+  H5Element,
+  H6Element
+} from '@/components/ui/heading-node'
 import { BlockquoteElement } from '@/components/ui/blockquote-node'
 import {
   CodeBlockElement,
   CodeBlockElementStatic,
   CodeLineElement,
-  CodeSyntaxLeaf,
+  CodeSyntaxLeaf
 } from '@/components/ui/code-block-node'
 import { LinkElement } from '@/components/ui/link-node'
 import { LinkFloatingToolbar } from '@/components/ui/link-toolbar'
@@ -49,13 +57,13 @@ import {
   BulletedListElement,
   ListItemElement,
   NumberedListElement,
-  TaskListElement,
+  TaskListElement
 } from '@/components/ui/list-classic-node'
 import {
   TableElement,
   TableCellElement,
   TableCellHeaderElement,
-  TableRowElement,
+  TableRowElement
 } from '@/components/ui/table-node'
 
 /**
@@ -75,8 +83,8 @@ import {
 const DndPluginConfigured = DndPlugin.configure({
   options: { enableScroller: true },
   render: {
-    aboveSlate: ({ children }) => <DndProvider backend={HTML5Backend}>{children}</DndProvider>,
-  },
+    aboveSlate: ({ children }) => <DndProvider backend={HTML5Backend}>{children}</DndProvider>
+  }
 })
 
 export function getSharedPlatePlugins(
@@ -92,13 +100,13 @@ export function getSharedPlatePlugins(
   // we don't pull in hook-based popover machinery during static rendering.
   const linkPluginConfigured = exportMode
     ? LinkPlugin.configure({
-        render: { node: LinkElement },
+        render: { node: LinkElement }
       })
     : LinkPlugin.configure({
         render: {
           node: LinkElement,
-          afterEditable: () => <LinkFloatingToolbar />,
-        },
+          afterEditable: () => <LinkFloatingToolbar />
+        }
       })
 
   return [
@@ -132,14 +140,19 @@ export function getSharedPlatePlugins(
     ListItemPlugin.withComponent(ListItemElement),
     // Tables
     TablePlugin.configure({
-      node: { component: TableElement },
+      node: { component: TableElement }
     }),
     TableRowPlugin.withComponent(TableRowElement),
     TableCellPlugin.withComponent(TableCellElement),
     TableCellHeaderPlugin.withComponent(TableCellHeaderElement),
     // Markdown serialization
-    MarkdownPlugin,
+    MarkdownPlugin.configure({
+      options: {
+        // Enable GitHub Flavored Markdown (tables, task lists, strikethrough, autolinks).
+        remarkPlugins: [remarkGfm]
+      }
+    }),
     // DnD (edit-time only) — conditionally included via spread
-    ...(includeDnd ? [DndPluginConfigured] : []),
+    ...(includeDnd ? [DndPluginConfigured] : [])
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   resolve: {
     alias: {
+      '@': resolve(__dirname, 'src/renderer'),
       '@shared': resolve(__dirname, 'src/shared')
     }
   },


### PR DESCRIPTION
## Summary
- enable GitHub Flavored Markdown parsing for Plate so course pipe tables render as tables
- reuse the shared Plate plugin pipeline in learner mode to avoid renderer drift
- adjust read-only table layout to use fluid markdown-viewer sizing without unnecessary horizontal scrollbars
- bump app version to 0.2.5 and add CHANGELOG notes for production release prep

## Validation
- npm test
- npm run lint (passes with existing warnings)
- npm run build
- ./scripts/build-release-notes.sh v0.2.5

## Release prep notes
Current production is v0.2.4. This PR prepares v0.2.5 via package/package-lock version bump and a matching CHANGELOG section. After merge, create and push tag v0.2.5 to trigger .github/workflows/release.yml, which builds and publishes draft GitHub release artifacts via electron-builder.