### PR TITLE
Update GitHub Actions runtime to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Ensure Electron binary is installed
+        run: node node_modules/electron/install.js
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
 
@@ -9,7 +10,103 @@ permissions:
   contents: write
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      should_release: ${{ steps.release.outputs.should_release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            TAG="$REF_NAME"
+          else
+            VERSION="$(node -p "require('./package.json').version")"
+            LOCK_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+            TAG="v$VERSION"
+
+            if [[ "$VERSION" != "$LOCK_VERSION" ]]; then
+              echo "error: package.json version ($VERSION) does not match package-lock.json version ($LOCK_VERSION)" >&2
+              exit 1
+            fi
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "error: tag '$TAG' does not match expected vMAJOR.MINOR.PATCH format" >&2
+            exit 1
+          fi
+
+          if ! grep -qE "^## ${TAG//./\.}( |$|—|-|–)" CHANGELOG.md; then
+            echo "error: CHANGELOG.md is missing a section heading for $TAG" >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
+
+          # The tag push starts the real release workflow. Skip this branch-push
+          # run to avoid building and publishing the same version twice.
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
+
+  release-notes:
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build release notes from CHANGELOG.md
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: ./scripts/build-release-notes.sh "$TAG" > release-notes.md
+
+      - name: Create or update draft release notes
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file release-notes.md || true
+          fi
+
+          gh release edit "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --notes-file release-notes.md
+
   build:
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     strategy:
       matrix:
         include:
@@ -24,12 +121,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -47,33 +144,3 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-  release-notes:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate tag format
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "error: tag '$TAG' does not match expected vMAJOR.MINOR.PATCH format" >&2
-            exit 1
-          fi
-
-      - name: Build release notes from CHANGELOG.md
-        env:
-          TAG: ${{ github.ref_name }}
-        run: ./scripts/build-release-notes.sh "$TAG" > release-notes.md
-
-      - name: Apply release notes to draft release
-        env:
-          TAG: ${{ github.ref_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release edit "$TAG" \
-            --title "$TAG" \
-            --notes-file release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Ensure Electron binary is installed
+        run: node node_modules/electron/install.js
+
       - name: Build app
         run: npm run build
 

--- a/src/test/mocks/electron.ts
+++ b/src/test/mocks/electron.ts
@@ -1,0 +1,43 @@
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+export const app = {
+  getName: (): string => 'Praxis',
+  getPath: (name: string): string => join(tmpdir(), 'praxis-test-electron', name),
+  getVersion: (): string => '0.0.0-test',
+  isPackaged: false,
+  on: (): void => {},
+  quit: (): void => {},
+  whenReady: async (): Promise<void> => {}
+}
+
+export class BrowserWindow {
+  static getAllWindows(): BrowserWindow[] {
+    return []
+  }
+
+  loadURL(): void {}
+  on(): void {}
+  webContents = {
+    send: (): void => {}
+  }
+}
+
+export const nativeTheme = {
+  on: (): void => {},
+  shouldUseDarkColors: false,
+  themeSource: 'system'
+}
+
+export const screen = {
+  getPrimaryDisplay: (): { workArea: { width: number; height: number } } => ({
+    workArea: { width: 1280, height: 720 }
+  })
+}
+
+export default {
+  app,
+  BrowserWindow,
+  nativeTheme,
+  screen
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src/renderer'),
-      '@shared': resolve(__dirname, 'src/shared')
+      '@shared': resolve(__dirname, 'src/shared'),
+      electron: resolve(__dirname, 'src/test/mocks/electron.ts')
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- update GitHub Actions from actions/checkout@v4 and actions/setup-node@v4 to their latest major versions, v6, which run on GitHub's Node 24 action runtime
- update CI and release builds from Node.js 22 to Node.js 24
- automate release tagging after merges to main: when package.json/package-lock and CHANGELOG contain a new version, the release workflow creates the vX.Y.Z tag automatically
- create/update draft release notes before packaging so draft releases are not blank while artifacts are building

## Notes
- Existing v0.2.5 release workflow was triggered by the old workflow, so this PR affects future releases.
- The workflow skips branch-push packaging after it creates the tag; the tag-triggered run performs the actual package/publish step to avoid double publishing.

## Validation
- YAML diagnostics pass for .github/workflows/ci.yml and .github/workflows/release.yml
- git diff --check passes